### PR TITLE
Add api-pls as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/jmeas/api-pls-example/issues"
   },
-  "homepage": "https://github.com/jmeas/api-pls-example#readme"
+  "homepage": "https://github.com/jmeas/api-pls-example#readme",
+  "dependencies": {
+    "api-pls": "^0.5.0"
+  }
 }


### PR DESCRIPTION
Since this example requires api-pls, I added it as a dependency so that it can be used without needing to install api-pls globally.